### PR TITLE
Dschaeffer/server anim

### DIFF
--- a/scripts/Multplayer_Manager.gd
+++ b/scripts/Multplayer_Manager.gd
@@ -107,6 +107,7 @@ func attempt_broadcast_actions_to_remotes(packet: PackedByteArray):
 	# force send a client_action to server-client
 	player_socket.client_action(packet)
 	for c in multiplayer.get_peers():
+		# Do not broadcast an action request to the client who performed the action.
 		if c != message["PEER"]:
 			PeerGlobal.log_message("sending message to peer " + str(c)) 
 			player_socket.rpc_id(c, "client_action", packet)
@@ -114,7 +115,12 @@ func attempt_broadcast_actions_to_remotes(packet: PackedByteArray):
 @rpc("unreliable", "any_peer")
 func attempt_broadcast_movements_to_remotes(p : PackedByteArray):
 	#PeerGlobal.log_message("attempt_broadcast_movements_to_remotes(p : PackedByteArray) ")
-	player_socket.rpc("client_movement", p)
+	var message = bytes_to_var(p)
+	player_socket.client_movement(p)
+	for c in multiplayer.get_peers():
+		# Do not broadcast a movement request to the client who performed the movement.
+		if c != message["PEER"]:
+			player_socket.rpc("client_movement", p)
 
 @rpc("reliable", "authority")
 func high_latency_removal(peer_id):

--- a/scripts/Multplayer_Manager.gd
+++ b/scripts/Multplayer_Manager.gd
@@ -101,13 +101,19 @@ func add_player(peer_id):
 # Packets that account for the time it took to reach the server.
 @rpc("unreliable", "any_peer")
 func attempt_broadcast_actions_to_remotes(packet: PackedByteArray):
-	PeerGlobal.log_message("attempt_broadcast_actions_to_remotes(packet : PackedByteArray) ") 
+	PeerGlobal.log_message("attempt_broadcast_actions_to_remotes(packet : PackedByteArray) message = " + str(bytes_to_var(packet))) 
+	var message = bytes_to_var(packet)
 	#print("packet PackedByteArray: " + str(packet))
-	player_socket.rpc("client_action", packet)
+	# force send a client_action to server-client
+	player_socket.client_action(packet)
+	for c in multiplayer.get_peers():
+		if c != message["PEER"]:
+			PeerGlobal.log_message("sending message to peer " + str(c)) 
+			player_socket.rpc_id(c, "client_action", packet)
 
 @rpc("unreliable", "any_peer")
 func attempt_broadcast_movements_to_remotes(p : PackedByteArray):
-	PeerGlobal.log_message("attempt_broadcast_movements_to_remotes(p : PackedByteArray) ")
+	#PeerGlobal.log_message("attempt_broadcast_movements_to_remotes(p : PackedByteArray) ")
 	player_socket.rpc("client_movement", p)
 
 @rpc("reliable", "authority")

--- a/scripts/Multplayer_Manager.gd
+++ b/scripts/Multplayer_Manager.gd
@@ -24,6 +24,7 @@ func _ready() -> void:
 	player_socket.connect("broadcast_action", Callable(self, "attempt_broadcast_actions_to_remotes")
 , 0)
 	player_socket.connect("broadcast_movement", Callable(self, "attempt_broadcast_movements_to_remotes"))
+	player_socket.connect("broadcast_target", Callable(self, "attempt_broadcast_targets_to_remotes"))
 	pass # Replace with function body.
 
 
@@ -120,7 +121,14 @@ func attempt_broadcast_movements_to_remotes(p : PackedByteArray):
 	for c in multiplayer.get_peers():
 		# Do not broadcast a movement request to the client who performed the movement.
 		if c != message["PEER"]:
-			player_socket.rpc("client_movement", p)
+			player_socket.rpc_id(c, "client_movement", p)
+
+func attempt_broadcast_targets_to_remotes(p : PackedByteArray):
+	var message = bytes_to_var(p)
+	player_socket.client_target(p)
+	for c in multiplayer.get_peers():
+		if c != message["PEER"]:
+			player_socket.rpc_id(c, "client_target", p)
 
 @rpc("reliable", "authority")
 func high_latency_removal(peer_id):

--- a/scripts/actor.gd
+++ b/scripts/actor.gd
@@ -8,6 +8,7 @@ var hasCalled = false
 var desired_move = Vector3.ZERO
 var desired_turn = 0.0 # left or right -+ 
 var lock_targ_pos : Vector3 = Vector3.ZERO
+var lock_targ : CharacterBody3D = null
 # NOTE - Desired move used to handle everything. But locking on and strafing 
 # 		 involved having the directing you were looking, IE turned towards
 #		 and the direction of movement, be separate. 
@@ -175,7 +176,7 @@ func apply_animation_params():
 		animation_tree.set(ani, 1 if "block" in action_q.keys() else 0)
 	for ani in aset_MOVE:
 		animation_tree.set(ani, transformed_move_dir)
-	for ani in aset_TURN:			
+	for ani in aset_TURN:
 		animation_tree.set(ani, desired_turn)
 	for ani in aset_JUMP:
 		animation_tree.set(ani, 1 if desired_move.y > 0.5 else 0)

--- a/scripts/playerSocket_adventure.gd
+++ b/scripts/playerSocket_adventure.gd
@@ -141,7 +141,7 @@ func client_movement(p : PackedByteArray):
 	var message : Dictionary = bytes_to_var(p)
 	var mm = get_parent().get_parent().get_node("Multplayer Manager")
 	var peer_nodes = mm.get_children()
-	PeerGlobal.log_message("message: " + str(message))
+	#PeerGlobal.log_message("message: " + str(message))
 	for peer in peer_nodes:
 		if str(message['PEER']) == peer.name:
 			peer.handle_movement(message['MOVEMENT'])


### PR DESCRIPTION
Changes in this PR:

- Remote thrall rotation is now tracked with the client_movement function.
- Fixed issue where server client could not see animations of guest clients.
- Refactored locked_target so that the player nodes are now responsible for tracking who they are targeting.

You can test these additions by customizing instances:
`Debug > Customize Run Instances...` Then checking `Run Multiple Instances` and finally increase the number of instances from 1 to 2.