### PR TITLE
Implementation of Call Help Feature (summon redesigned) + More

### DIFF
--- a/scenes/main_scene.tscn
+++ b/scenes/main_scene.tscn
@@ -1078,6 +1078,17 @@ script = ExtResource("27_6v26p")
 [node name="ai_attack" type="Node" parent="skele_05"]
 script = ExtResource("28_5kths")
 
+[node name="skele_06" parent="." instance=ExtResource("26_5srmb")]
+transform = Transform3D(0.169353, 0, -1.78197, 0, 1.79, 0, 1.78197, 0, 0.169353, 55.7394, 0.329161, 15.4347)
+character = ExtResource("34_b3pdd")
+to_equip_wep = ExtResource("28_6apcs")
+
+[node name="footall_sfx3" type="Node" parent="skele_06"]
+script = ExtResource("27_6v26p")
+
+[node name="ai_attack" type="Node" parent="skele_06"]
+script = ExtResource("28_5kths")
+
 [connection signal="body_entered" from="adventure_mode_demoLevel/Door of Trials/Area3D" to="adventure_mode_demoLevel/Door of Trials" method="trigger_animation"]
 [connection signal="body_entered" from="adventure_mode_demoLevel/Door of Trials2/Area3D" to="adventure_mode_demoLevel/Door of Trials2" method="trigger_animation"]
 [connection signal="body_exited" from="adventure_mode_demoLevel/Door of Trials3/Area3D" to="adventure_mode_demoLevel/Door of Trials3" method="trigger_animation"]

--- a/scripts/actor.gd
+++ b/scripts/actor.gd
@@ -5,10 +5,14 @@ class_name Actor
 @export var character : Character
 var hasHealed = false
 var hasCalled = false
+var hasGrown = false
+var hasPower = false
 var desired_move = Vector3.ZERO
 var desired_turn = 0.0 # left or right -+ 
 var lock_targ_pos : Vector3 = Vector3.ZERO
 var lock_targ : CharacterBody3D = null
+var movement_target: Vector3 = Vector3.ZERO
+var is_moving_to_help: bool = false
 # NOTE - Desired move used to handle everything. But locking on and strafing 
 # 		 involved having the directing you were looking, IE turned towards
 #		 and the direction of movement, be separate. 
@@ -158,6 +162,14 @@ func _physics_process(_delta):
 	apply_animation_params()	
 	_TEMPORARY_fall_death()
 	return
+	# Handle the movement for the callForHelp() function
+	if is_moving_to_help:
+		# Set direction and use handle_movement
+		var direction = (movement_target - global_position).normalized()
+		handle_movement(direction)
+		# Turn off moving_to_help if within fighting distance
+		if global_position.distance_to(movement_target) < 3:
+			is_moving_to_help = false	
 
 
 


### PR DESCRIPTION
Introduction and redesign of several features, including:

- Redesigned the summon help feature to its original intention, which was to have enemies within a radius to walk towards an enemy calling for help (rather than teleporting).
![Screenshot 2025-04-13 222045](https://github.com/user-attachments/assets/bb1be690-f475-41d2-a3f1-2e3d7fda2381)

- Added the feature for an enemy to grow in size upon reaching a certain threshold (such as low health).
![Screenshot 2025-04-13 221903](https://github.com/user-attachments/assets/6e5b1dd7-d3f8-4f09-a54a-856100fc84aa)

- Added the feature for an enemy to gain a specified amount of strength attribute upon reaching a certain threshold.
- Added new large skeleton on map to help test and demonstrate the call help feature. 